### PR TITLE
Refactor DocumentType enum

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,6 +1,6 @@
 use bytes::Bytes;
-use clap::{Parser, ValueEnum};
-use shiva::core::{TransformerTrait};
+use clap::Parser;
+use shiva::core::{DocumentType, TransformerTrait};
 
 #[derive(Parser, Debug)]
 #[command(name="shiva", author, version, about, long_about = None)]
@@ -11,28 +11,11 @@ struct Args {
     #[arg(long)]
     output_file: String,
 
-    #[arg(long)]
+    #[arg(long, value_parser = DocumentType::variants_as_str() )]
     input_format: DocumentType,
 
-    #[arg(long)]
+    #[arg(long, value_parser = DocumentType::variants_as_str() )]
     output_format: DocumentType,
-}
-
-
-#[derive(Debug, Parser, Clone, ValueEnum)]
-pub enum DocumentType {
-    HTML,
-    Markdown,
-    Text,
-    PDF,
-    JSON,
-    CSV,
-    RTF,
-    DOCX,
-    XML,
-    XLS,
-    XLSX,
-    ODS,
 }
 
 
@@ -49,7 +32,7 @@ fn main() -> anyhow::Result<()> {
         DocumentType::HTML => shiva::html::Transformer::parse(&input_bytes)?,
         DocumentType::Text => shiva::text::Transformer::parse(&input_bytes)?,
         DocumentType::PDF => shiva::pdf::Transformer::parse(&input_bytes)?,
-        DocumentType::JSON => shiva::json::Transformer::parse(&input_bytes)?,
+        DocumentType::Json => shiva::json::Transformer::parse(&input_bytes)?,
         DocumentType::CSV => shiva::csv::Transformer::parse(&input_bytes)?,
         DocumentType::RTF => shiva::rtf::Transformer::parse(&input_bytes)?,
         DocumentType::DOCX => shiva::docx::Transformer::parse(&input_bytes)?,
@@ -64,7 +47,7 @@ fn main() -> anyhow::Result<()> {
         DocumentType::HTML => shiva::html::Transformer::generate(&document)?,
         DocumentType::Markdown => shiva::markdown::Transformer::generate(&document)?,
         DocumentType::PDF => shiva::pdf::Transformer::generate(&document)?,
-        DocumentType::JSON => shiva::json::Transformer::generate(&document)?,
+        DocumentType::Json => shiva::json::Transformer::generate(&document)?,
         DocumentType::CSV => shiva::csv::Transformer::generate(&document)?,
         DocumentType::RTF => shiva::rtf::Transformer::generate(&document)?,
         DocumentType::DOCX => shiva::docx::Transformer::generate(&document)?,

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -57,6 +57,8 @@ pulldown-cmark = { version = "0.11.0", optional = true }
 calamine = { version = "0.24.0", optional = true }
 rust_xlsxwriter = { version = "0.64.2", optional = true }
 shiva-spreadsheet-ods = { version = "0.0.2", optional = true }
+strum = { version = "0.26", features = ["derive"] }
+wasm-bindgen = "0.2.84"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 ureq = { version =  "2.9.7", optional = true}

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -59,9 +59,7 @@ rust_xlsxwriter = { version = "0.64.2", optional = true }
 shiva-spreadsheet-ods = { version = "0.0.2", optional = true }
 strum = { version = "0.26", features = ["derive"] }
 wasm-bindgen = "0.2.84"
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-ureq = { version =  "2.9.7", optional = true}
+ehttp = "=0.5.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = "0.2.92"
@@ -86,7 +84,7 @@ text = []
 csv = ["dep:csv"]
 markdown = ["regex", "pulldown-cmark"]
 html = ["scraper", "ego-tree"]
-pdf = ["lopdf", "typst", "ttf-parser", "comemo", "time", "typst-pdf", "ureq"]
+pdf = ["lopdf", "typst", "ttf-parser", "comemo", "time", "typst-pdf"]
 json = ["serde", "serde_json"]
 xml = ["serde", "serde-xml-rs", "quick-xml"]
 rtf = ["rtf-parser"]

--- a/lib/src/core.rs
+++ b/lib/src/core.rs
@@ -1,8 +1,10 @@
 use bytes::Bytes;
 #[cfg(feature = "json")]
 use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::wasm_bindgen;
 use std::fmt::Debug;
 use thiserror::Error;
+use strum::{VariantArray, EnumString, Display, IntoStaticStr, EnumCount};
 
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "json", derive(Serialize, Deserialize))]
@@ -146,4 +148,82 @@ pub fn disk_image_saver(path: &str) -> impl Fn(&Bytes, &str) -> anyhow::Result<(
         Ok(())
     };
     image_saver
+}
+
+
+#[wasm_bindgen]
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Eq, EnumString, Display, VariantArray, IntoStaticStr, EnumCount)]
+#[strum(serialize_all = "lowercase")]
+pub enum DocumentType {
+    HTML = 0,
+    Markdown = 1,
+    Text = 2,
+    PDF = 3,
+    Json = 4,
+    CSV = 5,
+    RTF = 6,
+    DOCX = 7,
+    XML = 8,
+    XLS = 9,
+    XLSX = 10,
+    ODS = 11,
+}
+
+impl DocumentType {
+    pub fn variants() -> &'static [DocumentType] {
+        DocumentType::VARIANTS
+    }
+
+    pub fn variants_as_str() -> Vec<&'static str> {
+        DocumentType::VARIANTS.iter().map(|v| v.into()).collect()
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use std::str::FromStr;
+
+    const VARIANTS: &[DocumentType] = &[
+        DocumentType::HTML, DocumentType::Markdown, DocumentType::Text,
+        DocumentType::PDF, DocumentType::Json, DocumentType::CSV,
+        DocumentType::RTF, DocumentType::DOCX, DocumentType::XML,
+        DocumentType::XLS, DocumentType::XLSX, DocumentType::ODS];
+
+    #[test]
+    fn test_document_type_count() {
+        assert_eq!(VARIANTS.len(), DocumentType::COUNT);
+    }
+
+    #[test]
+    fn test_document_type_as_list() {
+        assert_eq!(DocumentType::VARIANTS, VARIANTS);
+        assert!(DocumentType::VARIANTS.contains(&DocumentType::HTML));
+        assert!(DocumentType::VARIANTS.contains(&DocumentType::RTF));
+    }
+
+    #[test]
+    fn test_serialize_all_lower_case() {
+        assert_eq!("csv", DocumentType::CSV.to_string());
+        assert_eq!(DocumentType::PDF, DocumentType::from_str("pdf").unwrap());
+        assert_eq!("json", <&'static str>::from(DocumentType::Json));
+    }
+
+    #[test]
+    fn test_variants_as_str() {
+        let variants = DocumentType::variants_as_str();
+        assert_eq!(variants.len(), DocumentType::COUNT);
+        assert!(variants.contains(&"html"));
+        assert!(variants.contains(&"docx"));
+    }
+
+    #[test]
+    fn test_as_repr() {
+        assert_eq!(DocumentType::HTML as u8, 0);
+        assert_eq!(DocumentType::XLSX as u8, 10);
+    }
+
 }

--- a/lib/src/core.rs
+++ b/lib/src/core.rs
@@ -6,6 +6,8 @@ use std::fmt::Debug;
 use thiserror::Error;
 use strum::{VariantArray, EnumString, Display, IntoStaticStr, EnumCount};
 
+use crate::{csv, docx, html, json, markdown, ods, pdf, rtf, text, xls, xlsx, xml};
+
 #[derive(Debug, PartialEq)]
 #[cfg_attr(feature = "json", derive(Serialize, Deserialize))]
 pub struct Document {
@@ -35,13 +37,48 @@ impl Document {
             page_footer: vec![],
         }
     }
+
+    pub fn parse(input_bytes: &Bytes, document_type: DocumentType) -> anyhow::Result<Document> {
+        let document = match document_type {
+            DocumentType::Markdown => markdown::Transformer::parse(input_bytes)?,
+            DocumentType::HTML => html::Transformer::parse(input_bytes)?,
+            DocumentType::Text => text::Transformer::parse(input_bytes)?,
+            DocumentType::PDF => pdf::Transformer::parse(input_bytes)?,
+            DocumentType::Json => json::Transformer::parse(input_bytes)?,
+            DocumentType::CSV => csv::Transformer::parse(input_bytes)?,
+            DocumentType::RTF => rtf::Transformer::parse(input_bytes)?,
+            DocumentType::DOCX => docx::Transformer::parse(input_bytes)?,
+            DocumentType::XML => xml::Transformer::parse(input_bytes)?,
+            DocumentType::XLS => xls::Transformer::parse(input_bytes)?,
+            DocumentType::XLSX => xlsx::Transformer::parse(input_bytes)?,
+            DocumentType::ODS => ods::Transformer::parse(input_bytes)?,
+        };
+        Ok(document)
+    }
+
+    pub fn generate(&self, document_type: DocumentType) -> anyhow::Result<Bytes> {
+        let output = match document_type {
+            DocumentType::Markdown => markdown::Transformer::generate(self)?,
+            DocumentType::HTML => html::Transformer::generate(self)?,
+            DocumentType::Text => text::Transformer::generate(self)?,
+            DocumentType::PDF => pdf::Transformer::generate(self)?,
+            DocumentType::Json => json::Transformer::generate(self)?,
+            DocumentType::CSV => csv::Transformer::generate(self)?,
+            DocumentType::RTF => rtf::Transformer::generate(self)?,
+            DocumentType::DOCX => docx::Transformer::generate(self)?,
+            DocumentType::XML => xml::Transformer::generate(self)?,
+            DocumentType::XLS => xls::Transformer::generate(self)?,
+            DocumentType::XLSX => xlsx::Transformer::generate(self)?,
+            DocumentType::ODS => ods::Transformer::generate(self)?,
+        };
+        Ok(output)
+    }
 }
 
 pub trait TransformerTrait {
     fn parse(document: &Bytes) -> anyhow::Result<Document>;
     fn generate(document: &Document) -> anyhow::Result<Bytes>;
 }
-
 
 
 pub trait TransformerWithImageLoaderSaverTrait {

--- a/shiva-wasm/Cargo.toml
+++ b/shiva-wasm/Cargo.toml
@@ -30,7 +30,7 @@ features = [
 
 [dependencies.shiva]
 path = "../lib"
-features = ["html", "text", "csv", "markdown", "json", "xml","rtf", "docx", "xlsx", "xls", "ods",]
+features = ["html", "text", "csv", "markdown", "json", "xml","rtf", "docx", "xlsx", "xls", "ods", "pdf"]
 default-features = false
 
 [dev-dependencies]

--- a/shiva-wasm/src/lib.rs
+++ b/shiva-wasm/src/lib.rs
@@ -2,7 +2,7 @@ mod utils;
 
 use wasm_bindgen::prelude::*;
 
-use shiva::{core::TransformerTrait, core::DocumentType as FileFormat, *};
+use shiva::{core::DocumentType as FileFormat, core::Document};
 
 use crate::utils::set_panic_hook;
 
@@ -21,209 +21,20 @@ pub fn convert(
     output_format: FileFormat,
 ) -> Result<Vec<u8>, JsValue> {
     set_panic_hook();
-    let parsed_file;
-    match input_format {
-        FileFormat::Text => {
-            parsed_file = match text::Transformer::parse(&file.into()) {
-                Ok(parse_result) => parse_result,
-                Err(e) => {
-                    return Err(e.to_string().into());
-                }
-            }
-        }
-        FileFormat::Markdown => {
-            parsed_file = match markdown::Transformer::parse(&file.into()) {
-                Ok(parse_result) => parse_result,
-                Err(e) => {
-                    return Err(e.to_string().into());
-                }
-            }
-        }
-        FileFormat::DOCX => {
-            parsed_file = match docx::Transformer::parse(&file.into()) {
-                Ok(parse_result) => parse_result,
-                Err(e) => {
-                    return Err(e.to_string().into());
-                }
-            }
-        }
-        FileFormat::HTML => {
-            parsed_file = match html::Transformer::parse(&file.into()) {
-                Ok(parse_result) => parse_result,
-                Err(e) => {
-                    return Err(e.to_string().into());
-                }
-            }
-        }
-        FileFormat::Json => {
-            parsed_file = match json::Transformer::parse(&file.into()) {
-                Ok(parse_result) => parse_result,
-                Err(e) => {
-                    return Err(e.to_string().into());
-                }
-            }
-        }
-        FileFormat::XML => {
-            parsed_file = match xml::Transformer::parse(&file.into()) {
-                Ok(parse_result) => parse_result,
-                Err(e) => {
-                    return Err(e.to_string().into());
-                }
-            }
-        }
-        FileFormat::CSV => {
-            parsed_file = match csv::Transformer::parse(&file.into()) {
-                Ok(parse_result) => parse_result,
-                Err(e) => {
-                    return Err(e.to_string().into());
-                }
-            }
-        }
-        FileFormat::RTF => {
-            parsed_file = match rtf::Transformer::parse(&file.into()) {
-                Ok(parse_result) => parse_result,
-                Err(e) => {
-                    return Err(e.to_string().into());
-                }
-            }
-        }
-        FileFormat::XLS => {
-            parsed_file = match xls::Transformer::parse(&file.into()) {
-                Ok(parse_result) => parse_result,
-                Err(e) => {
-                    return Err(e.to_string().into());
-                }
-            }
-        }
-        FileFormat::XLSX => {
-            parsed_file = match xlsx::Transformer::parse(&file.into()) {
-                Ok(parse_result) => parse_result,
-                Err(e) => {
-                    return Err(e.to_string().into());
-                }
-            }
-        }
-        FileFormat::ODS => {
-            parsed_file = match ods::Transformer::parse(&file.into()) {
-                Ok(parse_result) => parse_result,
-                Err(e) => {
-                    return Err(e.to_string().into());
-                }
-            }
-        }
-    }
 
-    match output_format {
-        FileFormat::Text => {
-            let generated = match text::Transformer::generate(&parsed_file) {
-                Ok(res) => res,
-                Err(err) => {
-                    log!(" FileFormat::Text err {:#?}", err);
-                    return Err(err.to_string().into());
-                }
-            };
-            return Ok(generated.to_vec());
+    let parsed_file = match Document::parse(&file.into(),input_format) {
+        Ok(parse_result) => parse_result,
+        Err(e) => {
+            return Err(e.to_string().into());
         }
-        FileFormat::Markdown => {
-            let generated = match markdown::Transformer::generate(&parsed_file) {
-                Ok(res) => res,
-                Err(err) => {
-                    log!(" FileFormat::Markdown err {:#?}", err);
-                    return Err(err.to_string().into());
-                }
-            };
-            return Ok(generated.to_vec());
-        }
-        FileFormat::DOCX => {
-            let generated = match docx::Transformer::generate(&parsed_file) {
-                Ok(res) => res,
-                Err(err) => {
-                    log!(" FileFormat::Docx err {:#?}", err);
-                    return Err(err.to_string().into());
-                }
-            };
-            return Ok(generated.to_vec());
-        }
-        FileFormat::HTML => {
-            let generated = match html::Transformer::generate(&parsed_file) {
-                Ok(res) => res,
-                Err(err) => {
-                    log!(" FileFormat::Html err {:#?}", err);
-                    return Err(err.to_string().into());
-                }
-            };
-            return Ok(generated.to_vec());
-        }
-        FileFormat::Json => {
-            let generated = match json::Transformer::generate(&parsed_file) {
-                Ok(res) => res,
-                Err(err) => {
-                    log!(" FileFormat::Json err {:#?}", err);
-                    return Err(err.to_string().into());
-                }
-            };
-            return Ok(generated.to_vec());
-        }
-        FileFormat::XML => {
-            let generated = match xml::Transformer::generate(&parsed_file) {
-                Ok(res) => res,
-                Err(err) => {
-                    log!(" FileFormat::Xml err {:#?}", err);
-                    return Err(err.to_string().into());
-                }
-            };
-            return Ok(generated.to_vec());
-        }
-        FileFormat::CSV => {
-            let generated = match csv::Transformer::generate(&parsed_file) {
-                Ok(res) => res,
-                Err(err) => {
-                    log!(" FileFormat::Csv err {:#?}", err);
-                    return Err(err.to_string().into());
-                }
-            };
-            return Ok(generated.to_vec());
-        }
-        FileFormat::RTF => {
-            let generated = match rtf::Transformer::generate(&parsed_file) {
-                Ok(res) => res,
-                Err(err) => {
-                    log!(" FileFormat::Csv err {:#?}", err);
-                    return Err(err.to_string().into());
-                }
-            };
-            return Ok(generated.to_vec());
-        }
-        FileFormat::XLS => {
-            let generated = match xls::Transformer::generate(&parsed_file) {
-                Ok(res) => res,
-                Err(err) => {
-                    log!(" FileFormat::Csv err {:#?}", err);
-                    return Err(err.to_string().into());
-                }
-            };
-            return Ok(generated.to_vec());
-        }
-        FileFormat::XLSX => {
-            let generated = match xlsx::Transformer::generate(&parsed_file) {
-                Ok(res) => res,
-                Err(err) => {
-                    log!(" FileFormat::Csv err {:#?}", err);
-                    return Err(err.to_string().into());
-                }
-            };
-            return Ok(generated.to_vec());
-        }
-        FileFormat::ODS => {
-            let generated = match ods::Transformer::generate(&parsed_file) {
-                Ok(res) => res,
-                Err(err) => {
-                    log!(" FileFormat::Csv err {:#?}", err);
-                    return Err(err.to_string().into());
-                }
-            };
-            return Ok(generated.to_vec());
-        }
+    };
 
-    }
+    let generated = match parsed_file.generate(output_format) {
+        Ok(res) => res,
+        Err(err) => {
+            log!(" FileFormat::{} err {:#?}",output_format, err);
+            return Err(err.to_string().into());
+        }
+    };
+    return Ok(generated.to_vec());
 }

--- a/shiva-wasm/src/lib.rs
+++ b/shiva-wasm/src/lib.rs
@@ -2,7 +2,7 @@ mod utils;
 
 use wasm_bindgen::prelude::*;
 
-use shiva::{core::TransformerTrait, *};
+use shiva::{core::TransformerTrait, core::DocumentType as FileFormat, *};
 
 use crate::utils::set_panic_hook;
 
@@ -12,23 +12,6 @@ macro_rules! log {
     ( $( $t:tt )* ) => {
         web_sys::console::log_1(&format!( $( $t )* ).into());
     }
-}
-
-#[wasm_bindgen]
-#[repr(u8)]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum FileFormat {
-    Markdown = 0,
-    Docx = 1,
-    Html = 2,
-    Text = 3,
-    Json = 4,
-    Xml = 5,
-    Csv = 6,
-    Rtf = 7,
-    Xls = 8,    
-    Xlsx = 9,    
-    Ods = 10,
 }
 
 #[wasm_bindgen(catch)]
@@ -56,7 +39,7 @@ pub fn convert(
                 }
             }
         }
-        FileFormat::Docx => {
+        FileFormat::DOCX => {
             parsed_file = match docx::Transformer::parse(&file.into()) {
                 Ok(parse_result) => parse_result,
                 Err(e) => {
@@ -64,7 +47,7 @@ pub fn convert(
                 }
             }
         }
-        FileFormat::Html => {
+        FileFormat::HTML => {
             parsed_file = match html::Transformer::parse(&file.into()) {
                 Ok(parse_result) => parse_result,
                 Err(e) => {
@@ -80,7 +63,7 @@ pub fn convert(
                 }
             }
         }
-        FileFormat::Xml => {
+        FileFormat::XML => {
             parsed_file = match xml::Transformer::parse(&file.into()) {
                 Ok(parse_result) => parse_result,
                 Err(e) => {
@@ -88,7 +71,7 @@ pub fn convert(
                 }
             }
         }
-        FileFormat::Csv => {
+        FileFormat::CSV => {
             parsed_file = match csv::Transformer::parse(&file.into()) {
                 Ok(parse_result) => parse_result,
                 Err(e) => {
@@ -96,7 +79,7 @@ pub fn convert(
                 }
             }
         }
-        FileFormat::Rtf => {
+        FileFormat::RTF => {
             parsed_file = match rtf::Transformer::parse(&file.into()) {
                 Ok(parse_result) => parse_result,
                 Err(e) => {
@@ -104,7 +87,7 @@ pub fn convert(
                 }
             }
         }
-        FileFormat::Xls => {
+        FileFormat::XLS => {
             parsed_file = match xls::Transformer::parse(&file.into()) {
                 Ok(parse_result) => parse_result,
                 Err(e) => {
@@ -112,7 +95,7 @@ pub fn convert(
                 }
             }
         }
-        FileFormat::Xlsx => {
+        FileFormat::XLSX => {
             parsed_file = match xlsx::Transformer::parse(&file.into()) {
                 Ok(parse_result) => parse_result,
                 Err(e) => {
@@ -120,7 +103,7 @@ pub fn convert(
                 }
             }
         }
-        FileFormat::Ods => {
+        FileFormat::ODS => {
             parsed_file = match ods::Transformer::parse(&file.into()) {
                 Ok(parse_result) => parse_result,
                 Err(e) => {
@@ -151,7 +134,7 @@ pub fn convert(
             };
             return Ok(generated.to_vec());
         }
-        FileFormat::Docx => {
+        FileFormat::DOCX => {
             let generated = match docx::Transformer::generate(&parsed_file) {
                 Ok(res) => res,
                 Err(err) => {
@@ -161,7 +144,7 @@ pub fn convert(
             };
             return Ok(generated.to_vec());
         }
-        FileFormat::Html => {
+        FileFormat::HTML => {
             let generated = match html::Transformer::generate(&parsed_file) {
                 Ok(res) => res,
                 Err(err) => {
@@ -181,7 +164,7 @@ pub fn convert(
             };
             return Ok(generated.to_vec());
         }
-        FileFormat::Xml => {
+        FileFormat::XML => {
             let generated = match xml::Transformer::generate(&parsed_file) {
                 Ok(res) => res,
                 Err(err) => {
@@ -191,7 +174,7 @@ pub fn convert(
             };
             return Ok(generated.to_vec());
         }
-        FileFormat::Csv => {
+        FileFormat::CSV => {
             let generated = match csv::Transformer::generate(&parsed_file) {
                 Ok(res) => res,
                 Err(err) => {
@@ -201,7 +184,7 @@ pub fn convert(
             };
             return Ok(generated.to_vec());
         }
-        FileFormat::Rtf => {
+        FileFormat::RTF => {
             let generated = match rtf::Transformer::generate(&parsed_file) {
                 Ok(res) => res,
                 Err(err) => {
@@ -211,7 +194,7 @@ pub fn convert(
             };
             return Ok(generated.to_vec());
         }
-        FileFormat::Xls => {
+        FileFormat::XLS => {
             let generated = match xls::Transformer::generate(&parsed_file) {
                 Ok(res) => res,
                 Err(err) => {
@@ -221,7 +204,7 @@ pub fn convert(
             };
             return Ok(generated.to_vec());
         }
-        FileFormat::Xlsx => {
+        FileFormat::XLSX => {
             let generated = match xlsx::Transformer::generate(&parsed_file) {
                 Ok(res) => res,
                 Err(err) => {
@@ -231,7 +214,7 @@ pub fn convert(
             };
             return Ok(generated.to_vec());
         }
-        FileFormat::Ods => {
+        FileFormat::ODS => {
             let generated = match ods::Transformer::generate(&parsed_file) {
                 Ok(res) => res,
                 Err(err) => {


### PR DESCRIPTION
**Summary**
This Pull Request refactors the DocumentType enum to leverage the strum crate for deriving additional functionality, ensuring a more DRY (Don't Repeat Yourself) codebase. This improvement retains compatibility with clap for command-line argument parsing.
Also simplifying operations like parse, generate, or match document types.