### PR TITLE
Add bands report, format and orientation to Document in favor of Metatron

### DIFF
--- a/lib/src/csv.rs
+++ b/lib/src/csv.rs
@@ -71,7 +71,7 @@ impl TransformerTrait for Transformer {
     }
 
     fn generate(document: &Document) -> anyhow::Result<Bytes> {
-        let elements = document.elements.clone();
+        let elements = document.get_all_elements();
 
         let mut data: Vec<Vec<String>> = Vec::new();
 
@@ -80,8 +80,8 @@ impl TransformerTrait for Transformer {
                 // Create a new vector for the header row
                 let mut header_line = Vec::new();
                 for header in headers {
-                    if let Text { text, size: _ } = header.element {
-                        header_line.push(text)
+                    if let Text { text, size: _ } = &header.element {
+                        header_line.push(text.clone())
                     }
                 }
                 // Push header row to data
@@ -90,9 +90,9 @@ impl TransformerTrait for Transformer {
                 // Iterate over each row
                 for row in rows {
                     let mut curr_line = Vec::new(); // This must be inside the loop
-                    for cell in row.cells {
-                        if let Text { text, size: _ } = cell.element {
-                            curr_line.push(text)
+                    for cell in &row.cells {
+                        if let Text { text, size: _ } = &cell.element {
+                            curr_line.push(text.clone())
                         }
                     }
                     // Push each row to data

--- a/lib/src/docx.rs
+++ b/lib/src/docx.rs
@@ -381,7 +381,8 @@ impl TransformerTrait for Transformer {
             .add_abstract_numbering(abstract_numbering)
             .add_numbering(Numbering::new(2, 2));
 
-        for element in &document.elements {
+        // TODO: Consider to refactor this code to use the new #Band Enum (header, footer, etc)
+        for element in &document.get_all_elements() {
             match element {
                 Element::Header { level, text } => {
                     let size = match level {
@@ -546,9 +547,7 @@ mod tests {
         let parsed = docx::Transformer::parse(&documents_bytes)?;
 
         println!("Parsed - {:#?}", parsed);
-
-        let expected_result = Document {
-            elements: vec![
+        let elements = vec![
                 Element::Text {
                     text: "Warszawa, dnia {{DATA}} r. ".to_string(),
                     size: 16,
@@ -561,16 +560,8 @@ mod tests {
                     text: "".to_string(),
                     size: 16,
                 },
-            ],
-            page_width: 210.0,
-            page_height: 297.0,
-            left_page_indent: 10.0,
-            right_page_indent: 10.0,
-            top_page_indent: 10.0,
-            bottom_page_indent: 10.0,
-            page_header: vec![],
-            page_footer: vec![],
-        };
+            ];
+        let expected_result = Document::new(elements);
         assert_eq!(expected_result, parsed);
         Ok(())
     }

--- a/lib/src/markdown.rs
+++ b/lib/src/markdown.rs
@@ -360,14 +360,9 @@ impl TransformerWithImageLoaderSaverTrait for Transformer {
             function: &image_saver,
         };
 
-        let all_elements: Vec<&Element> = document
-            .page_header
-            .iter()
-            .chain(document.elements.iter())
-            .chain(document.page_footer.iter())
-            .collect();
+        let all_elements: Vec<&Element> = document.get_all_elements();
 
-        for element in &all_elements {
+        for element in all_elements {
             let node = element_to_ast_node(&arena, element, &image_num, &image_saver)?;
             root.append(node);
         }
@@ -670,30 +665,21 @@ blabla2 bla bla blabla bla bla blabla bla bla blabla bla bla bla"#;
 ### Third Header
             "#;
 
-        let result_doc = Document {
-            elements: vec![
-                Header {
-                    level: 1,
-                    text: "First header".to_string(),
-                },
-                Header {
-                    level: 2,
-                    text: "Second Header".to_string(),
-                },
-                Header {
-                    level: 3,
-                    text: "Third Header".to_string(),
-                },
-            ],
-            page_width: 210.0,
-            page_height: 297.0,
-            left_page_indent: 10.0,
-            right_page_indent: 10.0,
-            top_page_indent: 10.0,
-            bottom_page_indent: 10.0,
-            page_header: vec![],
-            page_footer: vec![],
-        };
+        let elements = vec![
+            Header {
+                level: 1,
+                text: "First header".to_string(),
+            },
+            Header {
+                level: 2,
+                text: "Second Header".to_string(),
+            },
+            Header {
+                level: 3,
+                text: "Third Header".to_string(),
+            },
+        ];
+        let result_doc = Document::new(elements);
 
         let parsed = Transformer::parse(&document.as_bytes().into()).unwrap();
 
@@ -709,70 +695,60 @@ blabla2 bla bla blabla bla bla blabla bla bla blabla bla bla bla"#;
 | Header      | Title       |
 | Paragraph   | Text        |
           "#;
-
-        let result_doc = Document {
-            elements: vec![Table {
-                headers: vec![
-                    TableHeader {
-                        element: Text {
-                            text: "Syntax".to_string(),
-                            size: 14,
+        let elements = vec![Table {
+            headers: vec![
+                TableHeader {
+                    element: Text {
+                        text: "Syntax".to_string(),
+                        size: 14,
+                    },
+                    width: 30.0,
+                },
+                TableHeader {
+                    element: Text {
+                        text: "Description".to_string(),
+                        size: 14,
+                    },
+                    width: 30.0,
+                },
+            ],
+            rows: vec![
+                TableRow {
+                    cells: vec![
+                        TableCell {
+                            element: Text {
+                                text: "Header".to_string(),
+                                size: 14,
+                            },
                         },
-                        width: 30.0,
-                    },
-                    TableHeader {
-                        element: Text {
-                            text: "Description".to_string(),
-                            size: 14,
+                        TableCell {
+                            element: Text {
+                                text: "Title".to_string(),
+                                size: 14,
+                            },
                         },
-                        width: 30.0,
-                    },
-                ],
-                rows: vec![
-                    TableRow {
-                        cells: vec![
-                            TableCell {
-                                element: Text {
-                                    text: "Header".to_string(),
-                                    size: 14,
-                                },
+                    ],
+                },
+                TableRow {
+                    cells: vec![
+                        TableCell {
+                            element: Text {
+                                text: "Paragraph".to_string(),
+                                size: 14,
                             },
-                            TableCell {
-                                element: Text {
-                                    text: "Title".to_string(),
-                                    size: 14,
-                                },
+                        },
+                        TableCell {
+                            element: Text {
+                                text: "Text".to_string(),
+                                size: 14,
                             },
-                        ],
-                    },
-                    TableRow {
-                        cells: vec![
-                            TableCell {
-                                element: Text {
-                                    text: "Paragraph".to_string(),
-                                    size: 14,
-                                },
-                            },
-                            TableCell {
-                                element: Text {
-                                    text: "Text".to_string(),
-                                    size: 14,
-                                },
-                            },
-                        ],
-                    },
-                ],
-            }],
-            page_width: 210.0,
-            page_height: 297.0,
-            left_page_indent: 10.0,
-            right_page_indent: 10.0,
-            top_page_indent: 10.0,
-            bottom_page_indent: 10.0,
-            page_header: vec![],
-            page_footer: vec![],
-        };
+                        },
+                    ],
+                },
+            ],
+        }];
 
+        let result_doc = Document::new(elements);
         let parsed = Transformer::parse_with_loader(&document.as_bytes().into(), disk_image_loader("test/data")).unwrap();
 
         assert_eq!(parsed, result_doc)

--- a/lib/src/ods.rs
+++ b/lib/src/ods.rs
@@ -102,7 +102,7 @@ impl TransformerTrait for Transformer {
             Ok(())
         }
         let mut sheet_index = 1;
-        for element in &document.elements {
+        for element in &document.get_all_elements() {
             generate_element(element, &mut workbook, sheet_index)?;
             sheet_index += 1;
         }

--- a/lib/src/pdf.rs
+++ b/lib/src/pdf.rs
@@ -332,15 +332,15 @@ mod tests {
         println!("==========================");
         // println!("{:?}", parsed_document);
         println!("==========================");
-        parsed_document.page_header = vec![Element::Text {
+        parsed_document.set_page_header(vec![Element::Text {
             text: "header".to_string(),
             size: 10,
-        }];
+        }]);
 
-        parsed_document.page_footer = vec![Element::Text {
+        parsed_document.set_page_footer(vec![Element::Text {
             text: "footer".to_string(),
             size: 10,
-        }];
+        }]);
         let generated_result = Transformer::generate(&parsed_document);
         assert!(generated_result.is_ok());
         std::fs::write("test/data/typst.pdf", generated_result.unwrap())?;
@@ -351,47 +351,37 @@ mod tests {
     #[test]
     fn test_hyperlink_generation() -> anyhow::Result<()> {
         use Element::*;
-
-        let document = Document {
-            elements: vec![
-                Paragraph {
-                    elements: vec![
-                        Text {
-                            text: "Line 1".to_owned(),
-                            size: 8,
-                        },
-                        Text {
-                            text: "Line 2".to_owned(),
-                            size: 8,
-                        },
-                        Text {
-                            text: "Line 3".to_owned(),
-                            size: 8,
-                        },
-                    ],
-                },
-                Hyperlink {
-                    title: "Example".to_owned(),
-                    url: "https://www.example.com".to_owned(),
-                    alt: "Example Site".to_owned(),
-                    size: 8,
-                },
-                Hyperlink {
-                    title: "GitHub".to_owned(),
-                    url: "https://www.github.com".to_owned(),
-                    alt: "GitHub".to_owned(),
-                    size: 8,
-                },
-            ],
-            page_width: 210.0,
-            page_height: 297.0,
-            left_page_indent: 10.0,
-            right_page_indent: 10.0,
-            top_page_indent: 20.0,
-            bottom_page_indent: 10.0,
-            page_header: vec![],
-            page_footer: vec![],
-        };
+        let elements = vec![
+            Paragraph {
+                elements: vec![
+                    Text {
+                        text: "Line 1".to_owned(),
+                        size: 8,
+                    },
+                    Text {
+                        text: "Line 2".to_owned(),
+                        size: 8,
+                    },
+                    Text {
+                        text: "Line 3".to_owned(),
+                        size: 8,
+                    },
+                ],
+            },
+            Hyperlink {
+                title: "Example".to_owned(),
+                url: "https://www.example.com".to_owned(),
+                alt: "Example Site".to_owned(),
+                size: 8,
+            },
+            Hyperlink {
+                title: "GitHub".to_owned(),
+                url: "https://www.github.com".to_owned(),
+                alt: "GitHub".to_owned(),
+                size: 8,
+            },
+        ];
+        let document = Document::new(elements);
 
         println!("==========================");
         println!("{:?}", document);

--- a/lib/src/rtf.rs
+++ b/lib/src/rtf.rs
@@ -174,14 +174,14 @@ impl TransformerTrait for Transformer {
         let mut level = 1;
         for styleblock in Parser::new(tokens).parse().unwrap().body.as_slice() {
             if styleblock.painter.font_size >= 30 && styleblock.painter.bold == true {
-                document.elements.push(Element::Header {
+                document.add_element(Element::Header {
                     level: level,
                     text: styleblock.text.to_owned(),
                 });
                 level += 1
             } else {
                 {
-                    document.elements.push(Element::Paragraph {
+                    document.add_element(Element::Paragraph {
                         elements: vec![Element::Text {
                             text: styleblock.text.to_owned(),
                             size: styleblock.painter.font_size as u8,
@@ -198,7 +198,7 @@ impl TransformerTrait for Transformer {
         let mut parent_indices = Vec::new();
 
         rtf_content.push_str("{\\rtf1\\ansi\\deff0"); //the standard title of an RTF document, which indicates that it is an RTF document using ANSI characters and the default font
-        for element in &document.elements {
+        for element in &document.get_all_elements() {
             match element {
 
                 Element::Header { level, text} => {

--- a/lib/src/text.rs
+++ b/lib/src/text.rs
@@ -136,7 +136,7 @@ impl TransformerTrait for Transformer {
                 Element::Hyperlink {
                     title, url, alt, ..
                 } => {
-                    if url == alt && alt == url {
+                    if url == alt {
                         markdown.push_str(&url.to_string());
                     } else {
                         markdown.push_str(&format!("[{}]({} \"{}\")", title, url, alt));
@@ -205,40 +205,18 @@ impl TransformerTrait for Transformer {
         let mut list_counters: Vec<usize> = Vec::new();
         let mut list_types: Vec<bool> = Vec::new();
 
-        for element in &document.page_header {
-            generate_element(
-                element,
-                &mut markdown,
-                0,
-                &mut list_counters,
-                &mut list_types,
-                &mut images,
-                &mut image_num,
-            )?;
-        }
-
-        for element in &document.elements {
-            generate_element(
-                element,
-                &mut markdown,
-                0,
-                &mut list_counters,
-                &mut list_types,
-                &mut images,
-                &mut image_num,
-            )?;
-        }
-
-        for element in &document.page_footer {
-            generate_element(
-                element,
-                &mut markdown,
-                0,
-                &mut list_counters,
-                &mut list_types,
-                &mut images,
-                &mut image_num,
-            )?;
+        for band in &document.bands {
+            for element in &document.get_elements_by_band(band) {
+                generate_element(
+                    element,
+                    &mut markdown,
+                    0,
+                    &mut list_counters,
+                    &mut list_types,
+                    &mut images,
+                    &mut image_num,
+                )?;
+            }
         }
 
         Ok(Bytes::from(markdown))
@@ -291,8 +269,8 @@ Second header
         };
         footer_elements.push(footer);
         header_elements.push(header);
-        parsed_document.page_footer = footer_elements;
-        parsed_document.page_header = header_elements;
+        parsed_document.set_page_footer(footer_elements);
+        parsed_document.set_page_header(header_elements);
         let generated_result = Transformer::generate(&parsed_document);
         assert!(generated_result.is_ok());
         // println!("{:?}", generated_result.unwrap());

--- a/lib/src/typst.rs
+++ b/lib/src/typst.rs
@@ -403,14 +403,14 @@ pub fn generate_document(document: &Document) -> anyhow::Result<(TypstString, Ha
 
     // Converting both headers and footers into a string repr of them in Typst
     let mut header_text = String::new();
-    document.page_header.iter().for_each(|el| match el {
+    document.get_page_header().iter().for_each(|el| match el {
         Text { text, size: _ } => {
             header_text.push_str(text);
         }
         _ => {}
     });
     let mut footer_text = String::new();
-    document.page_footer.iter().for_each(|el| match el {
+    document.get_page_footer().iter().for_each(|el| match el {
         Text { text, size: _ } => {
             footer_text.push_str(text);
         }
@@ -425,7 +425,7 @@ pub fn generate_document(document: &Document) -> anyhow::Result<(TypstString, Ha
 
     // Converting Document repr to one of typst string
     source.push_str(&footer_header_text);
-    for element in &document.elements {
+    for element in &document.get_all_elements() {
         process_element(&mut source, &mut img_map, element)?;
     }
 

--- a/test/src/html.rs
+++ b/test/src/html.rs
@@ -24,8 +24,8 @@ mod tests {
               "#;
 
         let parsed: Document = Transformer::parse(&html_document.as_bytes().into())?;
-        assert_eq!(parsed.elements.len(), 6);
-        let elements: Vec<Element> = parsed.elements;
+        assert_eq!(parsed.get_all_elements().len(), 6);
+        let elements: Vec<&Element> = parsed.get_all_elements();
         match &elements[0] {
             Header { level: _, text } => {
                 assert_eq!(text, "First header");
@@ -49,45 +49,34 @@ mod tests {
 <h6>Sixth header</h6>
 </body>
 </html>"#;
-
-        let html_document: Document = Document {
-            elements: [
-                Header {
-                    level: 1,
-                    text: "First header".to_string(),
-                },
-                Header {
-                    level: 2,
-                    text: "Second header".to_string(),
-                },
-                Header {
-                    level: 3,
-                    text: "Third header".to_string(),
-                },
-                Header {
-                    level: 4,
-                    text: "Fourth header".to_string(),
-                },
-                Header {
-                    level: 5,
-                    text: "Fifth header".to_string(),
-                },
-                Header {
-                    level: 6,
-                    text: "Sixth header".to_string(),
-                },
-            ]
-            .to_vec(),
-            page_width: 210.0,
-            page_height: 297.0,
-            left_page_indent: 10.0,
-            right_page_indent: 10.0,
-            top_page_indent: 10.0,
-            bottom_page_indent: 10.0,
-            page_header: [].to_vec(),
-            page_footer: [].to_vec(),
-        };
-
+        let elements = [
+            Header {
+                level: 1,
+                text: "First header".to_string(),
+            },
+            Header {
+                level: 2,
+                text: "Second header".to_string(),
+            },
+            Header {
+                level: 3,
+                text: "Third header".to_string(),
+            },
+            Header {
+                level: 4,
+                text: "Fourth header".to_string(),
+            },
+            Header {
+                level: 5,
+                text: "Fifth header".to_string(),
+            },
+            Header {
+                level: 6,
+                text: "Sixth header".to_string(),
+            },
+        ]
+        .to_vec();
+        let html_document: Document = Document::new(elements);
         let generated_result = Transformer::generate(&html_document);
         assert!(generated_result.is_ok());
         let generated_bytes = generated_result?;
@@ -114,8 +103,8 @@ mod tests {
 "#;
 
         let parsed: Document = Transformer::parse(&html_document.as_bytes().into())?;
-        assert_eq!(parsed.elements.len(), 6);
-        let elements: Vec<Element> = parsed.elements;
+        assert_eq!(parsed.get_all_elements().len(), 6);
+        let elements: Vec<&Element> = parsed.get_all_elements();
         match &elements[0] {
             Paragraph { elements } => match &elements[0] {
                 Text { text, size: _ } => {
@@ -141,61 +130,52 @@ mod tests {
 <p>Sixth Paragraph</p>
 </body>
 </html>"#;
-        let html_document: Document = Document {
-            elements: [
-                Paragraph {
-                    elements: [Text {
-                        text: "First Paragraph".to_string(),
-                        size: 8,
-                    }]
-                    .to_vec(),
-                },
-                Paragraph {
-                    elements: [Text {
-                        text: "Second Paragraph".to_string(),
-                        size: 8,
-                    }]
-                    .to_vec(),
-                },
-                Paragraph {
-                    elements: [Text {
-                        text: "Third Paragraph".to_string(),
-                        size: 8,
-                    }]
-                    .to_vec(),
-                },
-                Paragraph {
-                    elements: [Text {
-                        text: "Fourth Paragraph".to_string(),
-                        size: 8,
-                    }]
-                    .to_vec(),
-                },
-                Paragraph {
-                    elements: [Text {
-                        text: "Fifth Paragraph".to_string(),
-                        size: 8,
-                    }]
-                    .to_vec(),
-                },
-                Paragraph {
-                    elements: [Text {
-                        text: "Sixth Paragraph".to_string(),
-                        size: 8,
-                    }]
-                    .to_vec(),
-                },
-            ]
-            .to_vec(),
-            page_width: 210.0,
-            page_height: 297.0,
-            left_page_indent: 10.0,
-            right_page_indent: 10.0,
-            top_page_indent: 10.0,
-            bottom_page_indent: 10.0,
-            page_header: [].to_vec(),
-            page_footer: [].to_vec(),
-        };
+        let elements = [
+            Paragraph {
+                elements: [Text {
+                    text: "First Paragraph".to_string(),
+                    size: 8,
+                }]
+                .to_vec(),
+            },
+            Paragraph {
+                elements: [Text {
+                    text: "Second Paragraph".to_string(),
+                    size: 8,
+                }]
+                .to_vec(),
+            },
+            Paragraph {
+                elements: [Text {
+                    text: "Third Paragraph".to_string(),
+                    size: 8,
+                }]
+                .to_vec(),
+            },
+            Paragraph {
+                elements: [Text {
+                    text: "Fourth Paragraph".to_string(),
+                    size: 8,
+                }]
+                .to_vec(),
+            },
+            Paragraph {
+                elements: [Text {
+                    text: "Fifth Paragraph".to_string(),
+                    size: 8,
+                }]
+                .to_vec(),
+            },
+            Paragraph {
+                elements: [Text {
+                    text: "Sixth Paragraph".to_string(),
+                    size: 8,
+                }]
+                .to_vec(),
+            },
+        ]
+        .to_vec();
+        let html_document: Document = Document::new(elements);
         let generated_result = Transformer::generate(&html_document);
         assert!(generated_result.is_ok());
         let generated_bytes = generated_result?;
@@ -226,7 +206,7 @@ mod tests {
 </html>"#;
 
         let parsed: Document = Transformer::parse(&html_document.as_bytes().into())?;
-        let elements: Vec<Element> = parsed.elements;
+        let elements: Vec<&Element> = parsed.get_all_elements();
         match &elements[0] {
             List {
                 elements,
@@ -258,9 +238,7 @@ mod tests {
 </ul>
 </body>
 </html>"#;
-
-        let html_document: Document = Document {
-            elements: [
+        let elements = [
                 List {
                     elements: vec![{
                         ListItem {
@@ -288,16 +266,8 @@ mod tests {
                     numbered: false,
                 },
             ]
-            .to_vec(),
-            page_width: 210.0,
-            page_height: 297.0,
-            left_page_indent: 10.0,
-            right_page_indent: 10.0,
-            top_page_indent: 10.0,
-            bottom_page_indent: 10.0,
-            page_header: [].to_vec(),
-            page_footer: [].to_vec(),
-        };
+            .to_vec();
+        let html_document: Document = Document::new(elements);
         let generated_result = Transformer::generate(&html_document);
         assert!(generated_result.is_ok());
         let generated_bytes = generated_result?;
@@ -330,7 +300,7 @@ mod tests {
 </html>"#;
 
         let parsed: Document = Transformer::parse(&html_document.as_bytes().into())?;
-        let elements: Vec<Element> = parsed.elements;
+        let elements: Vec<&Element> = parsed.get_all_elements();
         match &elements[0] {
             Table { headers, rows } => {
                 match &headers[0] {
@@ -378,94 +348,84 @@ mod tests {
 </table>
 </body>
 </html>"#;
-
-        let html_document: Document = Document {
-            elements: [Table {
-                headers: vec![
-                    {
-                        TableHeader {
-                            element: {
-                                Text {
-                                    size: 8,
-                                    text: "Syntax".to_string(),
-                                }
-                            },
-                            width: 10.0,
-                        }
-                    },
-                    {
-                        TableHeader {
-                            element: {
-                                Text {
-                                    size: 8,
-                                    text: "Description".to_string(),
-                                }
-                            },
-                            width: 10.0,
-                        }
-                    },
-                ],
-                rows: vec![
-                    TableRow {
-                        cells: vec![
-                            {
-                                TableCell {
-                                    element: {
-                                        Text {
-                                            size: 8,
-                                            text: "Header".to_string(),
-                                        }
-                                    },
-                                }
-                            },
-                            {
-                                TableCell {
-                                    element: {
-                                        Text {
-                                            size: 8,
-                                            text: "Title".to_string(),
-                                        }
-                                    },
-                                }
-                            },
-                        ],
-                    },
-                    TableRow {
-                        cells: vec![
-                            {
-                                TableCell {
-                                    element: {
-                                        Text {
-                                            size: 8,
-                                            text: "Paragraph".to_string(),
-                                        }
-                                    },
-                                }
-                            },
-                            {
-                                TableCell {
-                                    element: {
-                                        Text {
-                                            size: 8,
-                                            text: "Text".to_string(),
-                                        }
-                                    },
-                                }
-                            },
-                        ],
-                    },
-                ],
-            }]
-            .to_vec(),
-            page_width: 210.0,
-            page_height: 297.0,
-            left_page_indent: 10.0,
-            right_page_indent: 10.0,
-            top_page_indent: 10.0,
-            bottom_page_indent: 10.0,
-            page_header: [].to_vec(),
-            page_footer: [].to_vec(),
-        };
+        let elements = [Table {
+            headers: vec![
+                {
+                    TableHeader {
+                        element: {
+                            Text {
+                                size: 8,
+                                text: "Syntax".to_string(),
+                            }
+                        },
+                        width: 10.0,
+                    }
+                },
+                {
+                    TableHeader {
+                        element: {
+                            Text {
+                                size: 8,
+                                text: "Description".to_string(),
+                            }
+                        },
+                        width: 10.0,
+                    }
+                },
+            ],
+            rows: vec![
+                TableRow {
+                    cells: vec![
+                        {
+                            TableCell {
+                                element: {
+                                    Text {
+                                        size: 8,
+                                        text: "Header".to_string(),
+                                    }
+                                },
+                            }
+                        },
+                        {
+                            TableCell {
+                                element: {
+                                    Text {
+                                        size: 8,
+                                        text: "Title".to_string(),
+                                    }
+                                },
+                            }
+                        },
+                    ],
+                },
+                TableRow {
+                    cells: vec![
+                        {
+                            TableCell {
+                                element: {
+                                    Text {
+                                        size: 8,
+                                        text: "Paragraph".to_string(),
+                                    }
+                                },
+                            }
+                        },
+                        {
+                            TableCell {
+                                element: {
+                                    Text {
+                                        size: 8,
+                                        text: "Text".to_string(),
+                                    }
+                                },
+                            }
+                        },
+                    ],
+                },
+            ],
+        }]
+        .to_vec();
+        let html_document: Document = Document::new(elements);
         let generated_result = Transformer::generate(&html_document);
         assert!(generated_result.is_ok());
         let generated_bytes = generated_result?;
@@ -491,7 +451,7 @@ mod tests {
         assert!(parsed.is_ok());
         assert!(parsed.is_ok());
         let parsed: Document = parsed?;
-        let elements: Vec<Element> = parsed.elements;
+        let elements: Vec<&Element> = parsed.get_all_elements();
         match &elements[0] {
             Paragraph { elements } => match &elements[0] {
                 Image(image) => {
@@ -515,44 +475,34 @@ mod tests {
 
         let image_path = format!("image{}.png", 1);
         let image_bytes = std::fs::read(image_path).unwrap_or_default();
-
-        let html_document: Document = Document {
-            elements: [Paragraph {
-                elements: vec![
-                    {
-                        Text {
-                            size: 8,
-                            text: "bla".to_string(),
-                        }
-                    },
-                    {
-                        Image(ImageData::new(
-                            Bytes::from(image_bytes),
-                            "Picture title2".to_string(),
-                            "Picture alt2".to_string(),
-                            ImageType::default().to_string(),
-                            ImageAlignment::default().to_string(),
-                            ImageDimension::default(),
-                        ))
-                    },
-                    {
-                        Text {
-                            size: 8,
-                            text: "bla bla".to_string(),
-                        }
-                    },
-                ],
-            }]
-            .to_vec(),
-            page_width: 210.0,
-            page_height: 297.0,
-            left_page_indent: 10.0,
-            right_page_indent: 10.0,
-            top_page_indent: 10.0,
-            bottom_page_indent: 10.0,
-            page_header: [].to_vec(),
-            page_footer: [].to_vec(),
-        };
+        let elements = [Paragraph {
+            elements: vec![
+                {
+                    Text {
+                        size: 8,
+                        text: "bla".to_string(),
+                    }
+                },
+                {
+                    Image(ImageData::new(
+                        Bytes::from(image_bytes),
+                        "Picture title2".to_string(),
+                        "Picture alt2".to_string(),
+                        ImageType::default().to_string(),
+                        ImageAlignment::default().to_string(),
+                        ImageDimension::default(),
+                    ))
+                },
+                {
+                    Text {
+                        size: 8,
+                        text: "bla bla".to_string(),
+                    }
+                },
+            ],
+        }]
+        .to_vec();
+        let html_document: Document = Document::new(elements);
         let generated_result = Transformer::generate(&html_document);
         assert!(generated_result.is_ok());
         let generated_bytes = generated_result?;
@@ -576,7 +526,7 @@ mod tests {
         assert!(parsed.is_ok());
         assert!(parsed.is_ok());
         let parsed: Document = parsed?;
-        let elements: Vec<Element> = parsed.elements;
+        let elements: Vec<&Element> = parsed.get_all_elements();
 
         match &elements[0] {
             Hyperlink {
@@ -603,44 +553,35 @@ mod tests {
 </body>
 </html>"#;
 
-        let html_document: Document = Document {
-            elements: [Paragraph {
-                elements: [
-                    Hyperlink {
-                        title: "http://example.com".to_string(),
-                        url: "http://example.com".to_string(),
-                        size: 8,
-                        alt: "http://example.com".to_string(),
-                    },
-                    Text {
-                        size: 8,
-                        text: "  ".to_string(),
-                    },
-                    Hyperlink {
-                        title: "Example".to_string(),
-                        url: "http://example.com".to_string(),
-                        size: 8,
-                        alt: "Example".to_string(),
-                    },
-                    Hyperlink {
-                        title: "Example".to_string(),
-                        url: "http://example.com".to_string(),
-                        size: 8,
-                        alt: "Example tooltip".to_string(),
-                    },
-                ]
-                .to_vec(),
-            }]
+        let elements = [Paragraph {
+            elements: [
+                Hyperlink {
+                    title: "http://example.com".to_string(),
+                    url: "http://example.com".to_string(),
+                    size: 8,
+                    alt: "http://example.com".to_string(),
+                },
+                Text {
+                    size: 8,
+                    text: "  ".to_string(),
+                },
+                Hyperlink {
+                    title: "Example".to_string(),
+                    url: "http://example.com".to_string(),
+                    size: 8,
+                    alt: "Example".to_string(),
+                },
+                Hyperlink {
+                    title: "Example".to_string(),
+                    url: "http://example.com".to_string(),
+                    size: 8,
+                    alt: "Example tooltip".to_string(),
+                },
+            ]
             .to_vec(),
-            page_width: 210.0,
-            page_height: 297.0,
-            left_page_indent: 10.0,
-            right_page_indent: 10.0,
-            top_page_indent: 10.0,
-            bottom_page_indent: 10.0,
-            page_header: [].to_vec(),
-            page_footer: [].to_vec(),
-        };
+        }]
+        .to_vec();
+        let html_document: Document = Document::new(elements);
         let generated_result = Transformer::generate(&html_document);
         assert!(generated_result.is_ok());
         let generated_bytes = generated_result?;
@@ -671,7 +612,7 @@ mod tests {
         };
 
         header_elements.push(header);
-        parsed.page_header = header_elements.clone();
+        parsed.set_page_header(header_elements.clone());
 
         Ok(())
     }
@@ -704,7 +645,7 @@ mod tests {
         };
 
         header_elements.push(header);
-        parsed.page_header = header_elements.clone();
+        parsed.set_page_header(header_elements.clone());
 
         let generated_result = Transformer::generate(&parsed);
         assert!(generated_result.is_ok());
@@ -736,7 +677,7 @@ mod tests {
         };
 
         footer_elements.push(footer);
-        parsed.page_footer = footer_elements.clone();
+        parsed.set_page_footer(footer_elements.clone());
 
         Ok(())
     }
@@ -769,7 +710,7 @@ mod tests {
         };
 
         footer_elements.push(footer);
-        parsed.page_footer = footer_elements.clone();
+        parsed.set_page_footer(footer_elements.clone());
 
         let generated_result = Transformer::generate(&parsed);
         assert!(generated_result.is_ok());


### PR DESCRIPTION
### Improvements to Document Structure and Page Formatting in favor of Metatron

As I began working on Metatron, I identified the need for more robust document structures. Specifically, the ability to define page formats, margins, and other layout-related parameters became essential. I also recognized the importance of report bands like title, header, footer, custom bands, and summary to generate more the one page and respect the sections.

These reporting bands are fundamental and already exist, but in a very simple way. The new concept had good adaptability to existing code, as demonstrated by the passing tests, the system now supports these structures efficiently (there are two fails, but it is some bug in Markdown generate, not related with this feature).

### Convention Over Configuration for Page Formats

In an effort to adopt more *Convention Over Configuration*, I've introduced a default page format/orientation structure (`page_format,page_orientation`) for the `Document` class. Users are no longer required (though they still can) to specify page dimensions manually. By default, documents will assume an A4 page size unless otherwise specified the correct type at any moment in generate or parse function.

This change not only simplifies the document creation process but also future-proofs the system by allowing different file types to have predefined page formats and dimensions based on their specific needs.

In the example below, if the user's XML file does not explicitly define the page dimensions, it will automatically fall back to the default A4 dimensions:

```rust
// Initialize dimensions
        let PageDimensions {
            mut page_width,
            mut page_height,
            mut page_margin_top,
            mut page_margin_bottom,
            mut page_margin_left,
            mut page_margin_right,
        } = PageFormat::default().dimensions();

        for child in element_data.unwrap().children.iter() {
            match child.name.as_str() {
                "page_width" => {
                    if let Some(value) = &child.text {
                        page_width = value.parse()?;
                    }
                }
                "page_height" => {
                    if let Some(value) = &child.text {
                        page_height = value.parse()?;
                    }
                }
			}
		}
```
